### PR TITLE
Add support for an implicit namespace prefix

### DIFF
--- a/syntaxes/avroavsc.tmLanguage.json
+++ b/syntaxes/avroavsc.tmLanguage.json
@@ -34,14 +34,15 @@
 		},
 		"name": {
 			"patterns": [{
-				"match": "(\")(name)(\"):\\s*(\")([A-Za-z_][A-Za-z0-9_]*)(\")",
+				"match": "(\")(name)(\"):\\s*(\")([A-Za-z_][A-Za-z0-9_]*\.)*([A-Za-z_][A-Za-z0-9_]*)(\")",
 				"captures": {
 					"1": { "name": "string.quoted.avroavsc"},
 					"2": { "name": "keyword.struct.avroavsc"},
 					"3": { "name": "string.quoted.avroavsc"},
 					"4": { "name": "string.quoted.avroavsc"},
 					"5": { "name": "entity.name.class.avroavsc"},
-					"6": { "name": "string.quoted.avroavsc"}
+					"6": { "name": "entity.name.class.avroavsc"},
+					"7": { "name": "string.quoted.avroavsc"}
 				}
 			}]
 		},


### PR DESCRIPTION
In the avro spec (https://avro.apache.org/docs/current/spec.html#names), the `name` field can have a namespace prepended instead of having a separate discreet `namespace` field alongside it. This change to the syntax definition allows some number (zero or more) namespace tokens to prefix the actual field name.