### PR TITLE
Relax documentSelector so validation can happen on untitled: scheme documents

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -1,21 +1,23 @@
-import * as path from 'path';
-import { workspace, ExtensionContext } from 'vscode';
+import * as path from "path";
+import { ExtensionContext } from "vscode";
 
 import {
   LanguageClient,
   LanguageClientOptions,
   ServerOptions,
-  TransportKind
-} from 'vscode-languageclient';
+  TransportKind,
+} from "vscode-languageclient";
 
 let client: LanguageClient;
 
 export function activate(context: ExtensionContext) {
   // The server is implemented in node
-  let serverModule = context.asAbsolutePath(path.join('server', 'out', 'server.js'));
+  let serverModule = context.asAbsolutePath(
+    path.join("server", "out", "server.js")
+  );
   // The debug options for the server
   // --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging
-  let debugOptions = { execArgv: ['--nolazy', '--inspect=6009'] };
+  let debugOptions = { execArgv: ["--nolazy", "--inspect=6009"] };
 
   // If the extension is launched in debug mode then the debug server options are used
   // Otherwise the run options are used
@@ -24,14 +26,14 @@ export function activate(context: ExtensionContext) {
     debug: {
       module: serverModule,
       transport: TransportKind.ipc,
-      options: debugOptions
-    }
+      options: debugOptions,
+    },
   };
 
   // Options to control the language client
   let clientOptions: LanguageClientOptions = {
     // Register the server for plain text documents
-    documentSelector: [{ scheme: 'file', language: 'avroavsc' }],
+    documentSelector: [{ language: "avroavsc" }],
     // synchronize: {
     //   // Notify the server about file changes to '.clientrc files contained in the workspace
     //   fileEvents: workspace.createFileSystemWatcher('**/.clientrc')
@@ -40,8 +42,8 @@ export function activate(context: ExtensionContext) {
 
   // Create the language client and start the client.
   client = new LanguageClient(
-    'languageServerExample',
-    'Language Server Example',
+    "languageServerExample",
+    "Language Server Example",
     serverOptions,
     clientOptions
   );


### PR DESCRIPTION
Remove the document filter limiting to file scheme documents, so that the tool may kick in for untitled new documents which have not yet been saved to disk.

(Apologies for the quote and import reformatting performed automatically)